### PR TITLE
Fix of temperature & humidity

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/Zwer2k/WeatherStationDataRx.git"
     },
-    "version": "0.3.0",
+    "version": "0.3.1",
     "frameworks": "arduino",
     "platforms": [
         "atmelavr",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Weather Station Data Receiver
-version=0.3.0
+version=0.3.1
 author=Zwer2k
 maintainer=Zwer2k
 sentence=

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,10 +10,19 @@
 
 [platformio]
 test_dir = examples/WeatherStationDemo
+extra_configs = *_env.ini
+;default_envs = esp12e
+;default_envs = esp32doit-devkit-v1
 
 [env:esp12e]
 platform = espressif8266
 board = esp12e
 framework = arduino
 test_build_project_src = yes
+monitor_speed = 115200
+
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
 monitor_speed = 115200

--- a/src/WeatherStationDataRx.cpp
+++ b/src/WeatherStationDataRx.cpp
@@ -175,8 +175,8 @@ char WeatherStationDataRx::readData()
                     {
                         bState ? batteryState |= 1 : batteryState &= 0; // wenn die Batterien schwach sind, Bit 0 von batteryState auf 1 setzen
 
-                        temperature = ((unsigned long)(rxBuffer >> 12) & 0xfff);                              // die Bits 12-23 enthalten den Temperaturwert (in 0.1 °C)
-                        humidity = ((unsigned long)((rxBuffer >> 24) & 0xf) * 10) + ((rxBuffer >> 28) & 0xf); // die Bits 24-27 (einzer) und 28-31 (zehner) enthalten den Luftfeuchtigkeitsert (in %)
+                        temperature = (long)(-2048 * ((rxBuffer >> 23) & 0x1)) + (unsigned long)((rxBuffer >> 12) & 0x7ff); // die Bits 12-23 enthalten den Temperaturwert (in 0.1 °C)
+                        humidity = (unsigned long)((rxBuffer >> 24) & 0xf)  + ((rxBuffer >> 28) & 0xf) * 10; // die Bits 24-27 (einzer) und 28-31 (zehner) enthalten den Luftfeuchtigkeitsert (in %)
 
                         DEBUG_PRINTF("Temperatur: %d.%d", (int)(temperature / 10), (int)(temperature % 10));
                         DEBUG_PRINT("°C")

--- a/src/WeatherStationDataRx.h
+++ b/src/WeatherStationDataRx.h
@@ -48,6 +48,7 @@ public:
     float readTemperature(bool inF = false);
     uint8_t readHumidity();
     float readWindSpeed(bool inKMH = false);
+    // 0 - N, 45 - NE, 90 - E, 135 - SE, 180 - S, 225 - SW, 270 - W, 315 - NW
     uint16_t readWindDirection();
     float readWindGust(bool inKMH = false);
     float readRainVolume();
@@ -70,7 +71,8 @@ private:
     bool pairingRequeredMessageSent = false;
 #endif
     bool buttonState;
-    uint16_t temperature, humidity, windSpeed, windDirection, windGust, rainVolume; // Variablen zum speichern der Daten
+    int16_t temperature;
+    uint16_t humidity, windSpeed, windDirection, windGust, rainVolume; // Variablen zum speichern der Daten
     byte batteryState = 0;                                                          // der Batterie-Status von beiden Sensoren (Bit 0 = Windsensor und Bit 1 = Regensensor)
     byte randomID = 0;                                                              // At power up (when the batteries are inserted) the sensor selects a random number.
 


### PR DESCRIPTION
Hi,
I have detected temperature & humidity issue.  I have tested only on my station (Auriol H13726), but the same stuff is described in the documentation (http://www.tfd.hu/tfdhu/files/wsprotocol/auriol_protocol_v20.pdf).

Humidity:
-  ones are on 6th byte and tens are on 7th byte.

Temperature:
- type long is 4-byte type, but the station sents only 3 bytes. It's mean for positive temperature it works but for negative it calculates a bad complement.
