### PR TITLE
Static pairing crashes on esp8266

### DIFF
--- a/src/WeatherStationDataRx.cpp
+++ b/src/WeatherStationDataRx.cpp
@@ -125,8 +125,9 @@ void WeatherStationDataRx::pair(byte pairedDevices[], byte pairedDevicesCount, v
     }
     else
     {
-        this->pairedDevices = (byte *)realloc(pairedDevices, pairedDevicesCount * sizeof(byte));
+        this->pairedDevices = (byte *)realloc(this->pairedDevices, pairedDevicesCount * sizeof(byte));
         memcpy(this->pairedDevices, pairedDevices, pairedDevicesCount);
+        this->pairedDevicesCount = pairedDevicesCount;
     }
 }
 


### PR DESCRIPTION
I've discovered an bug when setting paired devices manually.
```
wsdr.begin();
byte myDeviceIDs[] = {7, 63};
wsdr.pair(myDeviceIDs, sizeof(myDeviceIDs));
```
The line 128 caused crash, because wrong variable was referenced. Generally I don't think it's good idea to use the same variable name in function parameter as global variable. 

After I fixed that one a second bug presented itself. The number of paired devices `this->pairedDevicesCount` is never updated with the new value, which causes constant stream of `NDError`.